### PR TITLE
Make .NET 4.5 the minimum required version

### DIFF
--- a/VsRestart/source.extension.vsixmanifest
+++ b/VsRestart/source.extension.vsixmanifest
@@ -13,7 +13,7 @@
     <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
     <Dependency Id="Microsoft.VisualStudio.MPF.11.0" DisplayName="Visual Studio MPF 11.0" d:Source="Installed" Version="11.0" />
   </Dependencies>
   <Assets>


### PR DESCRIPTION
Fixes ilmax/vs-restart#1.